### PR TITLE
docs: fix simple typo, useage -> usage

### DIFF
--- a/readme-en.md
+++ b/readme-en.md
@@ -136,7 +136,7 @@ A good trading strategy needs a good stock.
 
 Good metric give you right direction. 
 
-1. basic useage about metric
+1. basic usage about metric
 2. visualization on metrics
 3. expand self-custom metric
 


### PR DESCRIPTION
There is a small typo in readme-en.md.

Should read `usage` rather than `useage`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md